### PR TITLE
Add Flush Queue on JS SDK initialization

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { useEdgeeDataCollection } from './lib/data-collection/data-collection.hook';
 import { Consent } from './lib/data-collection/data-collection.types';
+import { flushQueue } from './lib/data-collection/data-collection';
 
 /**
  * Interface representing the Edgee analytics object.
@@ -100,8 +101,12 @@ const EdgeeSdk = ({ src, dataInline }: EdgeeSdkProps): JSX.Element => {
       };
     })((window as Window).history);
 
+    if (window.edgee) flushQueue();
+    else window.addEventListener('edgee:loaded', flushQueue);
+
     // Cleanup function to restore the original pushState and replaceState methods
     return (): void => {
+      window.removeEventListener('edgee:loaded', flushQueue);
       // No cleanup actions are defined here, but this is where you would restore the original methods if needed
     };
   }, []);

--- a/src/lib/data-collection/data-collection.ts
+++ b/src/lib/data-collection/data-collection.ts
@@ -15,8 +15,8 @@ const eventQueue: (QueuedEvent<Page | User | Track | Consent> | QueuedConsentEve
 /**
  * Flushes the event queue and sends all stored events to `window.edgee` if available.
  */
-const flushQueue = () => {
-  if (typeof window !== 'undefined' && window.edgee) {
+export const flushQueue = () => {
+  if (typeof window !== 'undefined' && window.edgee && eventQueue.length > 0) {
     while (eventQueue.length > 0) {
       const event = eventQueue.shift();
       if (!event) return;


### PR DESCRIPTION
This PR introduces a flush of the React SDK Queue if needed, at the initizalization of the JS SDK.

The Queue is beeing flushed when:
- The EdgeeSDK Component is mounted AND `window.edgee` is defined
- The EdgeeSDK Component is mounted AND `edgee:loaded` event is triggered
- At any `useEdgeeDataCollection` Method Call.