### PR TITLE
Export Types & Rework Type names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-edgee",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "React component to use the Edgee SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { useEdgeeDataCollection } from './lib/data-collection/data-collection.hook';
-import { Consent } from './lib/data-collection/data-collection.types';
+import { ConsentStatus } from './lib/data-collection/data-collection.types';
 import { flushQueue } from './lib/data-collection/data-collection';
 
 /**
@@ -33,10 +33,10 @@ export interface Edgee {
   user: (arg?: string | object, components?: object) => void;
 
   /**
-   *  Consent management system that allows you to control data collection and anonymization based on user consent status.
-   * @param {Consent} status - Consent state. Could be pending, denied or granted.
+   *  ConsentStatus management system that allows you to control data collection and anonymization based on user consent status.
+   * @param {ConsentStatus} status - ConsentStatus state. Could be pending, denied or granted.
    */
-  consent: (status: Consent) => void;
+  consent: (status: ConsentStatus) => void;
 }
 
 // Extends the global Window interface to include the Edgee analytics object.
@@ -79,7 +79,7 @@ const EdgeeSdk = ({ src, dataInline }: EdgeeSdkProps): JSX.Element => {
       history.pushState = (...args) => {
         // Call the original pushState method
         const result = pushState.apply(history, args);
-        // Track the page view after a short delay to ensure the page has changed
+        // TrackData the page view after a short delay to ensure the page has changed
         setTimeout(() => {
           window.edgee.page();
         }, 200);
@@ -93,7 +93,7 @@ const EdgeeSdk = ({ src, dataInline }: EdgeeSdkProps): JSX.Element => {
       history.replaceState = (...args) => {
         // Call the original replaceState method
         const result = replaceState.apply(history, args);
-        // Track the page view after a short delay
+        // TrackData the page view after a short delay
         setTimeout(() => {
           window.edgee.page();
         }, 200);
@@ -180,4 +180,5 @@ EdgeeDataLayer.propTypes = {
   data: PropTypes.object,
 };
 
+export * from './lib/data-collection/data-collection.types';
 export default EdgeeSdk;

--- a/src/lib/data-collection/data-collection.hook.ts
+++ b/src/lib/data-collection/data-collection.hook.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { track, page, user, consent } from './data-collection';
-import { Consent, Page, Track, User } from './data-collection.types';
+import { ConsentStatus, PageData, TrackData, UserData } from './data-collection.types';
 
 /**
  * Custom hook `useEdgeeDataCollection`
@@ -9,46 +9,46 @@ import { Consent, Page, Track, User } from './data-collection.types';
  * - Returns memoized functions for tracking events and user identification.
  *
  * @returns {{
- *   track: (eventData: Track) => void;
- *   page: (pageData: Page) => void;
- *   user: (userData: User) => void;
- *   consent: (consent: Consent) => void;
+ *   track: (eventData: TrackData) => void;
+ *   page: (pageData: PageData) => void;
+ *   user: (userData: UserData) => void;
+ *   consent: (consent: ConsentStatus) => void;
  * }} Object containing the tracking functions.
  */
 export const useEdgeeDataCollection = () => {
   /**
    * Tracks a page event.
    *
-   * @param {Page} pageData - The page details to be sent to Edgee.
+   * @param {PageData} pageData - The page details to be sent to Edgee.
    */
-  const pageEvent = useCallback((pageData: Page) => {
+  const pageEvent = useCallback((pageData: PageData) => {
     page(pageData);
   }, []);
 
   /**
    * Tracks a custom event.
    *
-   * @param {Track} trackData - The event details to be sent to Edgee.
+   * @param {TrackData} trackData - The event details to be sent to Edgee.
    */
-  const trackEvent = useCallback((trackData: Track) => {
+  const trackEvent = useCallback((trackData: TrackData) => {
     track(trackData);
   }, []);
 
   /**
    * Identifies a user and associates events with them.
    *
-   * @param {User} userData - The user data to be sent to Edgee.
+   * @param {UserData} userData - The user data to be sent to Edgee.
    */
-  const userEvent = useCallback((userData: User) => {
+  const userEvent = useCallback((userData: UserData) => {
     user(userData);
   }, []);
 
   /**
    * Set the consent for a user.
    *
-   * @param {Consent} status - The status of the consent for the user.
+   * @param {ConsentStatus} status - The status of the consent for the user.
    */
-  const setConsent = useCallback((status: Consent) => {
+  const setConsent = useCallback((status: ConsentStatus) => {
     consent(status);
   }, []);
 

--- a/src/lib/data-collection/data-collection.ts
+++ b/src/lib/data-collection/data-collection.ts
@@ -1,16 +1,16 @@
 import { Edgee } from '../../index';
 import {
-  Page,
-  User,
-  Track,
-  Consent,
+  PageData,
+  UserData,
+  TrackData,
+  ConsentStatus,
   EdgeeMethod,
   EdgeeConsentMethod,
   QueuedEvent,
   QueuedConsentEvent,
 } from './data-collection.types';
 
-const eventQueue: (QueuedEvent<Page | User | Track | Consent> | QueuedConsentEvent)[] = [];
+const eventQueue: (QueuedEvent<PageData | UserData | TrackData> | QueuedConsentEvent)[] = [];
 
 /**
  * Flushes the event queue and sends all stored events to `window.edgee` if available.
@@ -37,7 +37,7 @@ export const flushQueue = () => {
  * @returns {EdgeeMethod<T>} A function that queues or sends the event.
  */
 const createMethod =
-  <T extends Page | User | Track>(method: Exclude<keyof Edgee, 'consent'>): EdgeeMethod<T> =>
+  <T extends PageData | UserData | TrackData>(method: Exclude<keyof Edgee, 'consent'>): EdgeeMethod<T> =>
   (arg: T, components?: Record<string, boolean>) => {
     if (typeof window !== 'undefined' && window.edgee) {
       flushQueue();
@@ -51,7 +51,7 @@ const createMethod =
  * Creates a consent method that queues events if `window.edgee` is not available yet.
  * @returns {EdgeeConsentMethod} A function that queues or sends the consent event.
  */
-const createConsentMethod = (): EdgeeConsentMethod => (arg: Consent) => {
+const createConsentMethod = (): EdgeeConsentMethod => (arg: ConsentStatus) => {
   if (typeof window !== 'undefined' && window.edgee) {
     flushQueue();
     window.edgee.consent(arg);
@@ -60,9 +60,9 @@ const createConsentMethod = (): EdgeeConsentMethod => (arg: Consent) => {
   }
 };
 
-export const track: EdgeeMethod<Track> = createMethod<Track>('track');
-export const user: EdgeeMethod<User> = createMethod<User>('user');
-export const page: EdgeeMethod<Page> = createMethod<Page>('page');
+export const track: EdgeeMethod<TrackData> = createMethod<TrackData>('track');
+export const user: EdgeeMethod<UserData> = createMethod<UserData>('user');
+export const page: EdgeeMethod<PageData> = createMethod<PageData>('page');
 export const consent: EdgeeConsentMethod = createConsentMethod();
 
 const EdgeeSDK = { track, user, page, consent };

--- a/src/lib/data-collection/data-collection.types.ts
+++ b/src/lib/data-collection/data-collection.types.ts
@@ -1,6 +1,6 @@
 import { Edgee } from '../../index';
 
-export interface Page {
+export interface PageData {
   name?: string;
   category?: string;
   keywords?: string[];
@@ -12,22 +12,22 @@ export interface Page {
   properties?: Record<string, unknown>;
 }
 
-export interface User {
+export interface UserData {
   user_id?: string;
   anonymous_id?: string;
   edgee_id: string;
   properties?: Record<string, unknown>;
 }
 
-export interface Track {
+export interface TrackData {
   name?: string;
   properties?: Record<string, unknown>;
 }
 
-export type Consent = 'granted' | 'denied' | 'pending';
+export type ConsentStatus = 'granted' | 'denied' | 'pending';
 
 export type EdgeeMethod<T> = (arg: T, components?: Record<string, boolean>) => void;
-export type EdgeeConsentMethod = (arg: Consent) => void;
+export type EdgeeConsentMethod = (arg: ConsentStatus) => void;
 
 export type QueuedEvent<T> = {
   method: Exclude<keyof Edgee, 'consent'>;
@@ -36,5 +36,5 @@ export type QueuedEvent<T> = {
 
 export type QueuedConsentEvent = {
   method: 'consent';
-  args: [Consent];
+  args: [ConsentStatus];
 };


### PR DESCRIPTION
This PR renames the exported types and adds an export for the new ReactSDK types to improve DX and TypeScript integration. 🚀